### PR TITLE
fixed mongodb

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "express-session": ">= 1.0.0",
     "memjs": ">= 0.8.4",
     "mocha": ">= 1.0.1",
-    "mongodb": ">= 0.0.1",
+    "mongodb": "1.x",
     "redis": ">= 0.10.1",
     "tingodb": ">= 0.0.1"
   },


### PR DESCRIPTION
```
sessionstore/lib/sessionstore.js:55
      throw err;
            ^
TypeError: Cannot read property 'ObjectID' of undefined
    at Object.<anonymous> (sessionstore/lib/databases/mongodb.js:6:30)
    at Module._compile (module.js:456:26)
    at Object.Module._extensions..js (module.js:474:10)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:312:12)
    at Module.require (module.js:364:17)
    at require (module.js:380:17)
    at getSpecificStore (sessionstore/lib/sessionstore.js:23:14)
    at Object.module.exports.createSessionStore (sessionstore/lib/sessionstore.js:52:15)
    at Object.<anonymous> (app.js:41:22)
```

`npm list` told me that I'm using `mongodb@2.0.0-alpha1`. This fixed it for me.
