### PR TITLE
Remove deprecated option max_attempts from Redis options

### DIFF
--- a/lib/databases/redis.js
+++ b/lib/databases/redis.js
@@ -15,7 +15,6 @@ var RedisSessionStore = function (options) {
     port: 6379,
     prefix: 'sess',
     ttl:  60 * 60 * 24 * 14, // 14 days
-    max_attempts: 1,
     retry_strategy: function (options) {
       return undefined;
     }//,


### PR DESCRIPTION
The [`max_attempts`](https://github.com/NodeRedis/node_redis#options-object-properties) option from `redis` seems to be deprecated in the latest version.

This change suppresses a log warning thrown by `redis`.

Unfortunately a user can't modify the options to set the `max_attempts` to `null` or `undefined` from outside this package, because `redis` checks [whether or not the `max_attempts` key exists](https://github.com/NodeRedis/node_redis/blob/master/index.js#L76) in the options.