### PR TITLE
Remove TTL from ES Index Operation

### DIFF
--- a/lib/databases/elasticsearch.js
+++ b/lib/databases/elasticsearch.js
@@ -151,7 +151,7 @@ _.extend(ElasticSearchSessionStore.prototype, {
         id: self.options.prefix + sid,
         opType: methodName,
         // version: sess._version > 2 ? sess._version - 1 : undefined,
-        ttl: ttl + 'ms',
+        //ttl: ttl + 'ms',
         body: sess,
         refresh: true
       }, function (err, res) {


### PR DESCRIPTION
Fixes #47 
Remove deprecated (now removed) TTL option.

See details: https://www.elastic.co/guide/en/elasticsearch/reference/2.0/docs-index_.html#index-ttl