### PR TITLE
Upgrade versions of lodash and async

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,9 +11,9 @@
     "lib": "./lib"
   },
   "dependencies": {
-    "async": "2.6.0",
+    "async": "2.6.2",
     "jsondate": "0.0.1",
-    "lodash": "4.17.10",
+    "lodash": "4.17.11",
     "parent-require": "1.0.0",
     "tolerance": "1.0.0"
   },


### PR DESCRIPTION
I'm currently using sessionstore and `npm audit` is yielding a warning about two of sessionstore's dependencies, lodash and async.
The issue stems from lodash having a [prototype pollution issue](https://www.npmjs.com/advisories/782) in versions bellow 17.10.11
Async also has lodash as a dependency, which was bumped to version 4.17.11 in Async@2.6.2.
Therefore I have upgrade lodash from version 4.17.10 to 4.17.11 and upgrade async from version 2.6.0 to 2.6.2.

Thanks for the time