### PR TITLE
fixed Mongodb DeprecationWarning: { useUnifiedTopology: true }

### DIFF
--- a/lib/databases/mongodb.js
+++ b/lib/databases/mongodb.js
@@ -49,6 +49,7 @@ var MongoSessionStore = function (options) {
   if (isNew) {
     defaultOpt.autoReconnect = false;
     defaultOpt.useNewUrlParser = true;
+    defaultOpt.useUnifiedTopology = true;
     _.defaults(options.options, defaultOpt);
   } else {
     defaultOpt.auto_reconnect = false;


### PR DESCRIPTION
added `defaultOpt.useUnifiedTopology = true;` to remove `DeprecationWarning: pass option { useUnifiedTopology: true } to the MongoClient constructor`